### PR TITLE
Add unique ID to entities

### DIFF
--- a/custom_components/tilt_pi/entity.py
+++ b/custom_components/tilt_pi/entity.py
@@ -21,6 +21,7 @@ class TiltEntity(CoordinatorEntity[TiltPiDataUpdateCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._mac_id = hydrometer.mac_id
+        self._attr_unique_id = hydrometer.mac_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, hydrometer.mac_id)},
             name=f"Tilt {hydrometer.color}",


### PR DESCRIPTION
## Changes

Fixes an issue where when viewing an identity in HASS, the following message was displayed:

> This entity ('binary_sensor.tiltpi_omega_status') does not have a unique ID, therefore its settings cannot be managed from the UI. See the [documentation](https://www.home-assistant.io/faq/unique_id) for more detail.

Adding the unique attribute ID should circumvent this.